### PR TITLE
편지 삭제 및 복구 기능 추가

### DIFF
--- a/src/main/java/com/letter2sea/be/exception/type/LetterExceptionType.java
+++ b/src/main/java/com/letter2sea/be/exception/type/LetterExceptionType.java
@@ -1,0 +1,28 @@
+package com.letter2sea.be.exception.type;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum LetterExceptionType implements ExceptionType {
+    LETTER_NOT_FOUND("LETTER001", "존재하지 않는 편지입니다.", HttpStatus.NOT_FOUND);
+
+    private final String errorCode;
+    private final String message;
+    private final HttpStatus httpStatus;
+
+    @Override
+    public String getErrorCode() {
+        return this.errorCode;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return this.message;
+    }
+
+    @Override
+    public HttpStatus getStatus() {
+        return this.httpStatus;
+    }
+}

--- a/src/main/java/com/letter2sea/be/letter/controller/MailBoxController.java
+++ b/src/main/java/com/letter2sea/be/letter/controller/MailBoxController.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -47,5 +48,12 @@ public class MailBoxController {
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
         Long memberId = jwtProvider.decode(authorization);
         return letterService.findReplyDetail(id, replyId, memberId);
+    }
+
+    @PostMapping("/{id}")
+    public void getDelete(@PathVariable Long id,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+        Long memberId = jwtProvider.decode(authorization);
+        letterService.delete(id, memberId);
     }
 }

--- a/src/main/java/com/letter2sea/be/letter/domain/Letter.java
+++ b/src/main/java/com/letter2sea/be/letter/domain/Letter.java
@@ -54,4 +54,7 @@ public class Letter extends BaseTimeEntity {
 
     private Long replyLetterId;
 
+    public void updateDeletedAt() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/letter2sea/be/letter/domain/Letter.java
+++ b/src/main/java/com/letter2sea/be/letter/domain/Letter.java
@@ -3,7 +3,6 @@ package com.letter2sea.be.letter.domain;
 import com.letter2sea.be.common.util.BaseTimeEntity;
 import com.letter2sea.be.mailbox.domain.MailBox;
 import com.letter2sea.be.member.Member;
-import com.letter2sea.be.trash.domain.Trash;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -41,9 +40,6 @@ public class Letter extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "letter")
     private final List<MailBox> mailBoxes = new ArrayList<>();
-
-    @OneToMany(mappedBy = "letter")
-    private final List<Trash> TrashList = new ArrayList<>();
 
     private String title;
 

--- a/src/main/java/com/letter2sea/be/letter/domain/Letter.java
+++ b/src/main/java/com/letter2sea/be/letter/domain/Letter.java
@@ -3,6 +3,7 @@ package com.letter2sea.be.letter.domain;
 import com.letter2sea.be.common.util.BaseTimeEntity;
 import com.letter2sea.be.mailbox.domain.MailBox;
 import com.letter2sea.be.member.Member;
+import com.letter2sea.be.trash.domain.Trash;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -40,6 +41,9 @@ public class Letter extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "letter")
     private final List<MailBox> mailBoxes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "letter")
+    private final List<Trash> TrashList = new ArrayList<>();
 
     private String title;
 

--- a/src/main/java/com/letter2sea/be/letter/domain/Letter.java
+++ b/src/main/java/com/letter2sea/be/letter/domain/Letter.java
@@ -57,4 +57,8 @@ public class Letter extends BaseTimeEntity {
     public void updateDeletedAt() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void restoreDeletedAt() {
+        this.deletedAt = null;
+    }
 }

--- a/src/main/java/com/letter2sea/be/letter/repository/LetterRepository.java
+++ b/src/main/java/com/letter2sea/be/letter/repository/LetterRepository.java
@@ -18,6 +18,9 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
 
     Optional<Letter> findByIdAndWriterId(Long id, Long writerId);
 
+    @Query(value = "select * from Letter as l where l.id = :id", nativeQuery = true)
+    Optional<Letter> findByIdIgnoreDeletedAt(@Param("id") Long id);
+
     boolean existsByWriterIdAndReplyLetterId(Long writerId, Long replyLetterId);
 
     //작성자가 아니면서, replyLetterId가 null인

--- a/src/main/java/com/letter2sea/be/letter/service/LetterService.java
+++ b/src/main/java/com/letter2sea/be/letter/service/LetterService.java
@@ -66,7 +66,7 @@ public class LetterService {
         if (readLetters.isEmpty()) {
             List<Letter> unreadLetters = letterRepository.findAllByWriterNotAndReplyLetterIdIsNull(member);
             if (unreadLetters.isEmpty()) {
-                throw new RuntimeException("더이상 읽을 편지가 없습니다.");
+                return null;
             }
             return unreadLetters.get(random.nextInt(unreadLetters.size())).getId();
             //읽을 편지가 없다면 에러메시지를 응답값으로 전달 예정
@@ -74,7 +74,7 @@ public class LetterService {
         List<Letter> unReadLetters = letterRepository.findAllByWriterNotAndIdNotIn(
             member, readLetters);
         if (unReadLetters.isEmpty()) {
-            throw new RuntimeException("더이상 읽을 편지가 없습니다.");
+            return null;
         }
         return unReadLetters.get(random.nextInt(unReadLetters.size())).getId();
     }

--- a/src/main/java/com/letter2sea/be/mailbox/MailBoxRepository.java
+++ b/src/main/java/com/letter2sea/be/mailbox/MailBoxRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface MailBoxRepository extends JpaRepository<MailBox, Long> {
 
     MailBox findByLetterIdAndMemberId(Long letterId, Long memberId);
+
+    boolean existsByLetterIdAndMemberId(Long letterId, Long memberId);
 }

--- a/src/main/java/com/letter2sea/be/mailbox/MailBoxRepository.java
+++ b/src/main/java/com/letter2sea/be/mailbox/MailBoxRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MailBoxRepository extends JpaRepository<MailBox, Long> {
 
+    MailBox findByLetterIdAndMemberId(Long letterId, Long memberId);
 }

--- a/src/main/java/com/letter2sea/be/mailbox/domain/MailBox.java
+++ b/src/main/java/com/letter2sea/be/mailbox/domain/MailBox.java
@@ -10,7 +10,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,14 +31,8 @@ public class MailBox extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     private Member member;
 
-    private LocalDateTime deletedAt;
-
     public MailBox(Letter letter, Member member) {
         this.letter = letter;
         this.member = member;
-    }
-
-    public void updateDeletedAt() {
-        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/letter2sea/be/member/Member.java
+++ b/src/main/java/com/letter2sea/be/member/Member.java
@@ -2,6 +2,7 @@ package com.letter2sea.be.member;
 
 import com.letter2sea.be.common.util.BaseTimeEntity;
 import com.letter2sea.be.mailbox.domain.MailBox;
+import com.letter2sea.be.trash.domain.Trash;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -31,6 +32,9 @@ public class Member extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "member")
     private List<MailBox> mailBoxes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<Trash> TrashList = new ArrayList<>();
 
     @Builder
     public Member(Long kakaoId, String email, String nickname, String refreshToken) {

--- a/src/main/java/com/letter2sea/be/trash/TrashController.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashController.java
@@ -1,0 +1,36 @@
+package com.letter2sea.be.trash;
+
+import com.letter2sea.be.auth.jwt.JwtProvider;
+import com.letter2sea.be.trash.dto.TrashListResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/trash")
+public class TrashController {
+
+    private final JwtProvider jwtProvider;
+    private final TrashService trashService;
+
+    @GetMapping
+    public List<TrashListResponse> getList(
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+        Long memberId = jwtProvider.decode(authorization);
+        return trashService.findList(memberId);
+    }
+
+    @PostMapping("{Id}")
+    public void restore(@PathVariable Long id,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+        Long memberId = jwtProvider.decode(authorization);
+
+    }
+}

--- a/src/main/java/com/letter2sea/be/trash/TrashController.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashController.java
@@ -6,6 +6,7 @@ import com.letter2sea.be.trash.dto.TrashListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,5 +41,12 @@ public class TrashController {
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
         Long memberId = jwtProvider.decode(authorization);
         trashService.restore(id, memberId);
+    }
+
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+        Long memberId = jwtProvider.decode(authorization);
+        trashService.delete(id, memberId);
     }
 }

--- a/src/main/java/com/letter2sea/be/trash/TrashController.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +33,12 @@ public class TrashController {
         @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization){
         Long memberId = jwtProvider.decode(authorization);
         return trashService.findDetail(id, memberId);
+    }
+
+    @PostMapping("/{id}")
+    public void restore(@PathVariable Long id,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+        Long memberId = jwtProvider.decode(authorization);
+        trashService.restore(id, memberId);
     }
 }

--- a/src/main/java/com/letter2sea/be/trash/TrashController.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashController.java
@@ -1,13 +1,13 @@
 package com.letter2sea.be.trash;
 
 import com.letter2sea.be.auth.jwt.JwtProvider;
+import com.letter2sea.be.trash.dto.TrashDetailResponse;
 import com.letter2sea.be.trash.dto.TrashListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,10 +27,10 @@ public class TrashController {
         return trashService.findList(memberId);
     }
 
-    @PostMapping("{Id}")
-    public void restore(@PathVariable Long id,
-        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+    @GetMapping("/{id}")
+    public TrashDetailResponse getDetail(@PathVariable Long id,
+        @RequestHeader(HttpHeaders.AUTHORIZATION) String authorization){
         Long memberId = jwtProvider.decode(authorization);
-
+        return trashService.findDetail(id, memberId);
     }
 }

--- a/src/main/java/com/letter2sea/be/trash/TrashRepository.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashRepository.java
@@ -10,4 +10,8 @@ public interface TrashRepository extends JpaRepository<Trash, Long> {
     List<Trash> findAllByMemberId(Long memberId);
 
     Optional<Trash> findByIdAndMemberId(Long id, Long memberId);
+
+    boolean existsByIdAndMemberId(Long id, Long memberId);
+
+    void deleteByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/letter2sea/be/trash/TrashRepository.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashRepository.java
@@ -1,0 +1,8 @@
+package com.letter2sea.be.trash;
+
+import com.letter2sea.be.trash.domain.Trash;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TrashRepository extends JpaRepository<Trash, Long> {
+
+}

--- a/src/main/java/com/letter2sea/be/trash/TrashRepository.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashRepository.java
@@ -2,10 +2,12 @@ package com.letter2sea.be.trash;
 
 import com.letter2sea.be.trash.domain.Trash;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrashRepository extends JpaRepository<Trash, Long> {
 
     List<Trash> findAllByMemberId(Long memberId);
 
+    Optional<Trash> findByIdAndMemberId(Long id, Long memberId);
 }

--- a/src/main/java/com/letter2sea/be/trash/TrashRepository.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashRepository.java
@@ -1,8 +1,11 @@
 package com.letter2sea.be.trash;
 
 import com.letter2sea.be.trash.domain.Trash;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrashRepository extends JpaRepository<Trash, Long> {
+
+    List<Trash> findAllByMemberId(Long memberId);
 
 }

--- a/src/main/java/com/letter2sea/be/trash/TrashService.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashService.java
@@ -1,0 +1,27 @@
+package com.letter2sea.be.trash;
+
+import com.letter2sea.be.member.repository.MemberRepository;
+import com.letter2sea.be.trash.dto.TrashListResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TrashService {
+
+    private final MemberRepository memberRepository;
+    private final TrashRepository trashRepository;
+    public List<TrashListResponse> findList(Long memberId) {
+        findMember(memberId);
+        return trashRepository.findAllByMemberId(memberId).stream()
+            .map(TrashListResponse::new)
+            .toList();
+    }
+
+    private void findMember(Long memberId) {
+        memberRepository.findById(memberId).orElseThrow();
+    }
+}

--- a/src/main/java/com/letter2sea/be/trash/TrashService.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashService.java
@@ -55,6 +55,19 @@ public class TrashService {
 
         trashRepository.deleteByIdAndMemberId(id,memberId);
     }
+
+    @Transactional
+    public void delete(Long id, Long memberId) {
+        findMember(memberId);
+        boolean existsByIdAndMemberId = trashRepository.existsByIdAndMemberId(id, memberId);
+
+        if (!existsByIdAndMemberId) {
+            throw new Letter2SeaException(LETTER_NOT_FOUND);
+        }
+
+        trashRepository.deleteByIdAndMemberId(id,memberId);
+    }
+
     private void findMember(Long memberId) {
         memberRepository.findById(memberId)
             .orElseThrow(() -> new Letter2SeaException(MEMBER_NOT_FOUND));

--- a/src/main/java/com/letter2sea/be/trash/TrashService.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashService.java
@@ -1,5 +1,6 @@
 package com.letter2sea.be.trash;
 
+import com.letter2sea.be.letter.repository.LetterRepository;
 import com.letter2sea.be.member.repository.MemberRepository;
 import com.letter2sea.be.trash.domain.Trash;
 import com.letter2sea.be.trash.dto.TrashDetailResponse;
@@ -16,6 +17,7 @@ public class TrashService {
 
     private final TrashRepository trashRepository;
     private final MemberRepository memberRepository;
+    private final LetterRepository letterRepository;
 
     public List<TrashListResponse> findList(Long memberId) {
         findMember(memberId);
@@ -30,6 +32,20 @@ public class TrashService {
        return new TrashDetailResponse(findTrash);
     }
 
+    @Transactional
+    public void restore(Long id, Long memberId) {
+        findMember(memberId);
+        boolean existsByIdAndMemberId = trashRepository.existsByIdAndMemberId(id, memberId);
+        Trash deletedLetter = trashRepository.findById(id).orElseThrow();
+
+        //해당부분에서 에러남
+        deletedLetter.getLetter().restoreDeletedAt();
+        if (!existsByIdAndMemberId) {
+            throw new RuntimeException("존재하지 않은 편지입니다.");
+        }
+
+        trashRepository.deleteByIdAndMemberId(id,memberId);
+    }
     private void findMember(Long memberId) {
         memberRepository.findById(memberId).orElseThrow();
     }

--- a/src/main/java/com/letter2sea/be/trash/TrashService.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashService.java
@@ -1,6 +1,8 @@
 package com.letter2sea.be.trash;
 
 import com.letter2sea.be.member.repository.MemberRepository;
+import com.letter2sea.be.trash.domain.Trash;
+import com.letter2sea.be.trash.dto.TrashDetailResponse;
 import com.letter2sea.be.trash.dto.TrashListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -12,13 +14,20 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class TrashService {
 
-    private final MemberRepository memberRepository;
     private final TrashRepository trashRepository;
+    private final MemberRepository memberRepository;
+
     public List<TrashListResponse> findList(Long memberId) {
         findMember(memberId);
         return trashRepository.findAllByMemberId(memberId).stream()
             .map(TrashListResponse::new)
             .toList();
+    }
+
+    public TrashDetailResponse findDetail(Long id, Long memberId) {
+        findMember(memberId);
+        Trash findTrash = trashRepository.findByIdAndMemberId(id, memberId).orElseThrow();
+       return new TrashDetailResponse(findTrash);
     }
 
     private void findMember(Long memberId) {

--- a/src/main/java/com/letter2sea/be/trash/domain/Trash.java
+++ b/src/main/java/com/letter2sea/be/trash/domain/Trash.java
@@ -29,9 +29,7 @@ public class Trash {
     @Column(columnDefinition = "MEDIUMTEXT")
     private String content;
 
-    @JoinColumn
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Letter letter;
+    private Long letterId;
 
     @JoinColumn
     @ManyToOne(fetch = FetchType.LAZY)
@@ -42,7 +40,7 @@ public class Trash {
     public Trash(Letter letter, Member member) {
         this.title = letter.getTitle();
         this.content = letter.getContent();
-        this.letter = letter;
+        this.letterId = letter.getId();
         this.member = member;
         this.deletedAt = LocalDateTime.now();
     }

--- a/src/main/java/com/letter2sea/be/trash/domain/Trash.java
+++ b/src/main/java/com/letter2sea/be/trash/domain/Trash.java
@@ -1,8 +1,8 @@
-package com.letter2sea.be.mailbox.domain;
+package com.letter2sea.be.trash.domain;
 
-import com.letter2sea.be.common.util.BaseTimeEntity;
 import com.letter2sea.be.letter.domain.Letter;
 import com.letter2sea.be.member.Member;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -18,11 +18,16 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class MailBox extends BaseTimeEntity {
+public class Trash {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    private String title;
+
+    @Column(columnDefinition = "MEDIUMTEXT")
+    private String content;
 
     @JoinColumn
     @ManyToOne(fetch = FetchType.LAZY)
@@ -34,12 +39,11 @@ public class MailBox extends BaseTimeEntity {
 
     private LocalDateTime deletedAt;
 
-    public MailBox(Letter letter, Member member) {
+    public Trash(Letter letter, Member member) {
+        this.title = letter.getTitle();
+        this.content = letter.getContent();
         this.letter = letter;
         this.member = member;
-    }
-
-    public void updateDeletedAt() {
         this.deletedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/letter2sea/be/trash/dto/TrashDetailResponse.java
+++ b/src/main/java/com/letter2sea/be/trash/dto/TrashDetailResponse.java
@@ -1,0 +1,21 @@
+package com.letter2sea.be.trash.dto;
+
+import com.letter2sea.be.trash.domain.Trash;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class TrashDetailResponse {
+
+    private final Long id;
+    private final String title;
+    private final String content;
+    private final LocalDateTime deletedAt;
+
+    public TrashDetailResponse(Trash trash) {
+        this.id = trash.getId();
+        this.title = trash.getTitle();
+        this.content = trash.getContent();
+        this.deletedAt = trash.getDeletedAt();
+    }
+}

--- a/src/main/java/com/letter2sea/be/trash/dto/TrashListResponse.java
+++ b/src/main/java/com/letter2sea/be/trash/dto/TrashListResponse.java
@@ -15,7 +15,7 @@ public class TrashListResponse {
 
     public TrashListResponse(Trash trash) {
         this.id = trash.getId();
-        this.letterId = trash.getLetter().getId();
+        this.letterId = trash.getLetterId();
         this.title = trash.getTitle();
         this.deletedAt = trash.getDeletedAt();
     }

--- a/src/main/java/com/letter2sea/be/trash/dto/TrashListResponse.java
+++ b/src/main/java/com/letter2sea/be/trash/dto/TrashListResponse.java
@@ -1,0 +1,22 @@
+package com.letter2sea.be.trash.dto;
+
+import com.letter2sea.be.trash.domain.Trash;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class TrashListResponse {
+
+    private final Long id;
+
+    private final Long letterId;
+    private final String title;
+    private final LocalDateTime deletedAt;
+
+    public TrashListResponse(Trash trash) {
+        this.id = trash.getId();
+        this.letterId = trash.getLetter().getId();
+        this.title = trash.getTitle();
+        this.deletedAt = trash.getDeletedAt();
+    }
+}


### PR DESCRIPTION
- [x] 편지 삭제 기능
- [x] 편지 복구 기능
- [x]  편지 영구 삭제 기능

Letter 의 @where SQL 로 인해 휴지통에서 SoftDelete 된 편지의 조회가 되지 않기 때문에 Trash 와 Letter 의 연관관계를 끊고, NativeQuery 를 통해 조회 하였음.
현재 Trash 엔티티만 hard delete 가 가능하고 mailbox(중복 편지 줍기 문제 발생) & letter(모든 유저에게서 편지가 삭제되는 문제 발생) 에서는 soft delete 만 시행 중