### PR TITLE
메뉴 Info 반환 값 수정

### DIFF
--- a/src/main/java/com/letter2sea/be/auth/service/LoginService.java
+++ b/src/main/java/com/letter2sea/be/auth/service/LoginService.java
@@ -29,6 +29,7 @@ public class LoginService {
     public void updateRefreshToken(String jwtRefreshToken, Long memberId) {
         Member findMember = memberRepository.findById(memberId).orElseThrow(RuntimeException::new);
         findMember.updateRefreshToken(jwtRefreshToken);
+        findMember.updateLastLoginTime();
     }
 
     @Transactional

--- a/src/main/java/com/letter2sea/be/member/Member.java
+++ b/src/main/java/com/letter2sea/be/member/Member.java
@@ -8,6 +8,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -30,6 +32,7 @@ public class Member extends BaseTimeEntity {
     private String nickname;
     private String refreshToken;
     private int thankCount;
+    private LocalDateTime lastLoginAt;
 
     @OneToMany(mappedBy = "member")
     private List<MailBox> mailBoxes = new ArrayList<>();
@@ -44,6 +47,7 @@ public class Member extends BaseTimeEntity {
         this.nickname = nickname;
         this.refreshToken = refreshToken;
         this.thankCount = 0;
+        this.lastLoginAt = LocalDateTime.now();
     }
 
     public void updateEmail(String email) {
@@ -56,5 +60,9 @@ public class Member extends BaseTimeEntity {
 
     public void increaseThankCount() {
         this.thankCount++;
+    }
+
+    public void updateLastLoginTime() {
+        this.lastLoginAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/com/letter2sea/be/member/Member.java
+++ b/src/main/java/com/letter2sea/be/member/Member.java
@@ -32,6 +32,7 @@ public class Member extends BaseTimeEntity {
     private String nickname;
     private String refreshToken;
     private int thankCount;
+    private boolean notificationEnabled;
     private LocalDateTime lastLoginAt;
 
     @OneToMany(mappedBy = "member")
@@ -50,8 +51,9 @@ public class Member extends BaseTimeEntity {
         this.lastLoginAt = LocalDateTime.now();
     }
 
-    public void updateEmail(String email) {
+    public void update(String email, boolean notificationEnabled) {
         this.email = email;
+        this.notificationEnabled = notificationEnabled;
     }
 
     public void updateRefreshToken(String refreshToken) {
@@ -64,5 +66,9 @@ public class Member extends BaseTimeEntity {
 
     public void updateLastLoginTime() {
         this.lastLoginAt = LocalDateTime.now();
+    }
+
+    public boolean isFirstLogin() {
+        return this.getCreatedAt() == this.lastLoginAt;
     }
 }

--- a/src/main/java/com/letter2sea/be/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/letter2sea/be/member/dto/MemberUpdateRequest.java
@@ -2,5 +2,5 @@ package com.letter2sea.be.member.dto;
 
 import jakarta.validation.constraints.Email;
 
-public record MemberUpdateRequest(@Email String email) {
+public record MemberUpdateRequest(@Email String email, boolean notificationEnabled) {
 }

--- a/src/main/java/com/letter2sea/be/member/dto/MemberUpdateRequest.java
+++ b/src/main/java/com/letter2sea/be/member/dto/MemberUpdateRequest.java
@@ -2,5 +2,5 @@ package com.letter2sea.be.member.dto;
 
 import jakarta.validation.constraints.Email;
 
-public record MemberUpdateRequest(@Email String email, boolean notificationEnabled) {
+public record MemberUpdateRequest(@Email String emailAddress, boolean notificationEnabled) {
 }

--- a/src/main/java/com/letter2sea/be/member/service/MemberService.java
+++ b/src/main/java/com/letter2sea/be/member/service/MemberService.java
@@ -17,7 +17,7 @@ public class MemberService {
     @Transactional
     public void update(Long memberId, MemberUpdateRequest updateRequest) {
         Member member = findMember(memberId);
-        member.update(updateRequest.email(), updateRequest.notificationEnabled());
+        member.update(updateRequest.emailAddress(), updateRequest.notificationEnabled());
     }
 
     private Member findMember(Long writerId) {

--- a/src/main/java/com/letter2sea/be/member/service/MemberService.java
+++ b/src/main/java/com/letter2sea/be/member/service/MemberService.java
@@ -17,7 +17,7 @@ public class MemberService {
     @Transactional
     public void update(Long memberId, MemberUpdateRequest updateRequest) {
         Member member = findMember(memberId);
-        member.updateEmail(updateRequest.email());
+        member.update(updateRequest.email(), updateRequest.notificationEnabled());
     }
 
     private Member findMember(Long writerId) {

--- a/src/main/java/com/letter2sea/be/menu/dto/MenuInfoResponse.java
+++ b/src/main/java/com/letter2sea/be/menu/dto/MenuInfoResponse.java
@@ -1,3 +1,11 @@
 package com.letter2sea.be.menu.dto;
 
-public record MenuInfoResponse(int receivedThankCount, int sentLetterCount, int sentReplyCount) {}
+import com.letter2sea.be.member.Member;
+
+public record MenuInfoResponse(int receivedThankCount, boolean firstLogin, String emailAddress, boolean notificationEnabled, int trashCount) {
+
+    public MenuInfoResponse(Member member, int trashCount) {
+        this(member.getThankCount(), member.isFirstLogin(), member.getEmail(),
+            member.isNotificationEnabled(), trashCount);
+    }
+}

--- a/src/main/java/com/letter2sea/be/menu/service/MenuService.java
+++ b/src/main/java/com/letter2sea/be/menu/service/MenuService.java
@@ -2,10 +2,10 @@ package com.letter2sea.be.menu.service;
 
 import com.letter2sea.be.exception.Letter2SeaException;
 import com.letter2sea.be.exception.type.MemberExceptionType;
-import com.letter2sea.be.letter.repository.LetterRepository;
 import com.letter2sea.be.member.Member;
 import com.letter2sea.be.member.repository.MemberRepository;
 import com.letter2sea.be.menu.dto.MenuInfoResponse;
+import com.letter2sea.be.trash.TrashRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,14 +13,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class MenuService {
     private final MemberRepository memberRepository;
-    private final LetterRepository letterRepository;
+    private final TrashRepository trashRepository;
 
     public MenuInfoResponse getMenuInfo(Long memberId) {
         Member member = findMember(memberId);
-        int sentLetterCount = letterRepository.countAllByWriterAndReplyLetterIdIsNull(member);
-        int sentReplyCount = letterRepository.countAllByWriterAndReplyLetterIdIsNotNull(member);
-
-        return new MenuInfoResponse(member.getThankCount(), sentLetterCount, sentReplyCount);
+        int trashCount = trashRepository.countAllByMemberId(member.getId());
+        return new MenuInfoResponse(member, trashCount);
     }
 
     private Member findMember(Long writerId) {

--- a/src/main/java/com/letter2sea/be/trash/TrashRepository.java
+++ b/src/main/java/com/letter2sea/be/trash/TrashRepository.java
@@ -7,8 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrashRepository extends JpaRepository<Trash, Long> {
-
-//    List<Trash> findAllByMemberId(Long memberId);
+    int countAllByMemberId(Long memberId);
 
     Page<Trash> findAllByMemberId(Long memberId, Pageable pageable);
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,6 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        format_sql: true
         dialect: org.hibernate.dialect.MySQLDialect
     defer-datasource-initialization: true
 


### PR DESCRIPTION
## 📃 Description
메뉴 Info 호출 시 현재 받은 감사 인사 수, 보낸 편지 수 , 보낸 답장 수를 반환하고 있으나
감사 인사 수, 첫 로그인인지 여부, 쓰레기통의 편지 개수, 알림받기 설정한 이메일 주소, 알림 받기 설정 여부  
반환으로 수정 필요.

## ☑ Todo
- [x] 유저 클래스에 마지막 로그인 시간, 알림 설정 여부 저장하는 칼럼 추가
- [x] 메뉴 인포 API 반환 값 수정 
- [x] 회원 정보 업데이트 시 이메일과 함께 알림 설정 여부도 추가할 수 있도록 수정 
## etc
