### PR TITLE
회원 탈퇴 기능 추가

### DIFF
--- a/src/main/java/com/letter2sea/be/exception/type/LetterExceptionType.java
+++ b/src/main/java/com/letter2sea/be/exception/type/LetterExceptionType.java
@@ -7,7 +7,8 @@ import org.springframework.http.HttpStatus;
 public enum LetterExceptionType implements ExceptionType {
     LETTER_NOT_FOUND("LETTER001", "존재하지 않는 편지입니다.", HttpStatus.NOT_FOUND),
     LETTER_ALREADY_DELETED("LETTER002", "이미 삭제한 편지입니다.", HttpStatus.BAD_REQUEST),
-    LETTER_ALREADY_READ("LETTER003", "이미 읽은 편지이거나 자신이 작성한 편지입니다.", HttpStatus.BAD_REQUEST);
+    LETTER_ALREADY_READ("LETTER003", "이미 읽은 편지이거나 자신이 작성한 편지입니다.", HttpStatus.BAD_REQUEST),
+    LETTER_ALREADY_REPLY("LETTER004", "이미 답장한 편지이거나 자신이 작성한 편지입니다.", HttpStatus.BAD_REQUEST);
 
     private final String errorCode;
     private final String message;

--- a/src/main/java/com/letter2sea/be/letter/repository/LetterRepository.java
+++ b/src/main/java/com/letter2sea/be/letter/repository/LetterRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -42,4 +43,8 @@ public interface LetterRepository extends JpaRepository<Letter, Long> {
 
     int countAllByWriterAndReplyLetterIdIsNull(Member writer);
     int countAllByWriterAndReplyLetterIdIsNotNull(Member writer);
+
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
+    @Query(value = "UPDATE letter l SET l.writer_id = NULL WHERE l.writer_id = :writerId", nativeQuery = true)
+    void detachFromWriter(@Param("writerId") Long writerId);
 }

--- a/src/main/java/com/letter2sea/be/member/Member.java
+++ b/src/main/java/com/letter2sea/be/member/Member.java
@@ -8,7 +8,6 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
-
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -35,11 +34,11 @@ public class Member extends BaseTimeEntity {
     private boolean notificationEnabled;
     private LocalDateTime lastLoginAt;
 
-    @OneToMany(mappedBy = "member")
-    private List<MailBox> mailBoxes = new ArrayList<>();
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
+    private final List<MailBox> mailBoxes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
-    private List<Trash> TrashList = new ArrayList<>();
+    @OneToMany(mappedBy = "member", orphanRemoval = true)
+    private final List<Trash> TrashList = new ArrayList<>();
 
     @Builder
     public Member(Long kakaoId, String email, String nickname, String refreshToken) {

--- a/src/main/java/com/letter2sea/be/member/controller/MemberController.java
+++ b/src/main/java/com/letter2sea/be/member/controller/MemberController.java
@@ -6,6 +6,7 @@ import com.letter2sea.be.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -24,5 +25,11 @@ public class MemberController {
         @Valid @RequestBody MemberUpdateRequest request) {
         Long memberId = jwtProvider.decode(authorization);
         memberService.update(memberId, request);
+    }
+
+    @DeleteMapping
+    public void delete(@RequestHeader(HttpHeaders.AUTHORIZATION) String authorization) {
+        Long memberId = jwtProvider.decode(authorization);
+        memberService.delete(memberId);
     }
 }

--- a/src/main/java/com/letter2sea/be/member/service/MemberService.java
+++ b/src/main/java/com/letter2sea/be/member/service/MemberService.java
@@ -20,6 +20,12 @@ public class MemberService {
         member.update(updateRequest.emailAddress(), updateRequest.notificationEnabled());
     }
 
+    @Transactional
+    public void delete(Long memberId) {
+        Member member = findMember(memberId);
+        memberRepository.delete(member);
+    }
+
     private Member findMember(Long writerId) {
         return memberRepository.findById(writerId)
             .orElseThrow(() -> new Letter2SeaException(MemberExceptionType.MEMBER_NOT_FOUND));

--- a/src/main/java/com/letter2sea/be/member/service/MemberService.java
+++ b/src/main/java/com/letter2sea/be/member/service/MemberService.java
@@ -2,6 +2,7 @@ package com.letter2sea.be.member.service;
 
 import com.letter2sea.be.exception.Letter2SeaException;
 import com.letter2sea.be.exception.type.MemberExceptionType;
+import com.letter2sea.be.letter.repository.LetterRepository;
 import com.letter2sea.be.member.Member;
 import com.letter2sea.be.member.dto.MemberUpdateRequest;
 import com.letter2sea.be.member.repository.MemberRepository;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
+    private final LetterRepository letterRepository;
 
     @Transactional
     public void update(Long memberId, MemberUpdateRequest updateRequest) {
@@ -23,6 +25,7 @@ public class MemberService {
     @Transactional
     public void delete(Long memberId) {
         Member member = findMember(memberId);
+        letterRepository.detachFromWriter(member.getId());
         memberRepository.delete(member);
     }
 


### PR DESCRIPTION
## 📃 Description
회원 탈퇴 기능을 구현한다.

## ☑ Todo
- [x] 회원 탈퇴 시 하드 딜리트로 유저의 정보를 삭제한다.
- [x] 회원 탈퇴 시 이미 보낸 편지들은 삭제되지 않는다.
- [x] 보낸 편지들 외에 mailbox, trash 등 중간 테이블의 객체들은 삭제된다.

## etc
- 회원 삭제 전에 해당 회원이 작성한 letter 의 writer 필드를 null 로 수정
- 회원 삭제 전에 연관관계를 끊고 캐시를 비우기 위해 flushAutomatically, clearAutomatically true 설정
- Letter 의 @Where 절을 무시하기 위해 native query 로 작성